### PR TITLE
fix: add context generation for clangd lsp(nvim) during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@
 
 [Mm]ake[Ff]ile
 **.make
+
+*.cache
+**compile_commands.json

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ BuildProject(){
     echo "==== Building Process Started ($CONFIG) ===="
     echo "Generating makefiles..."
     ./vendor/premake/premake5 gmake2
-    cd "$PROJECT_NAME/" && make
+    cd "$PROJECT_NAME/" && bear -- make
     echo "==== BUILD FINISHED ===="
     echo
 }


### PR DESCRIPTION
update build script to use bear to generate context file for clangd lsp

this fixes the 'include file not found' error in editor

this change requires [bear](https://github.com/rizsotto/Bear) be installed to work