### PR TITLE
Fix: Build issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,17 @@ OpenGL 4.6, glfw
 
 To install everything in linux mint run the following in terminal
 
-`sudo apt-get install mesa-utils mesa-common-dev libglfw3 libglfw3-dev bear`
+`sudo apt-get install mesa-utils mesa-common-dev bear`
 
 or equivalent package manager commands
 
 ## BUILDING
 
-- Go to root and call
-  `./scripts/build.sh`
+```
+- git clone git@github.com:WoodenNebula/Tic-Tac-Toe.git Tic-Tac-Toe
+- cd Tic-Tac-Toe
+- git submodule update --init
+- ./scripts/build.sh
+```
 
 If you get error saying linking fail, make sure to complete (Pre-requisite) first

--- a/Tic-Tac-Toe/Tic-Tac-Toe.lua
+++ b/Tic-Tac-Toe/Tic-Tac-Toe.lua
@@ -9,7 +9,7 @@ project "Tic-Tac-Toe"
     prebuildmessage ("---- Building Dependencies-GLFW ----")
 
     prebuildcommands {
-        "cmake -S %{wks.location}/dependencies/GLFW/ -B %{wks.location}/../build/GLFW/"
+        "cmake -S %{wks.location}/dependencies/GLFW/ -B %{wks.location}/../build/GLFW/ && make -C %{wks.location}/../build/GLFW/"
     }
 -- postbuildmessage ("Building Dependencies (GLFW) Complete")
 


### PR DESCRIPTION
- add missing command for make which solved the `libglfw3` not found error
- updated README to include proper build steps from cloning to running the program